### PR TITLE
Update package.json - upgraded sanitize-html to latest 2.3.3

### DIFF
--- a/packages/gatsby-transformer-remark/package.json
+++ b/packages/gatsby-transformer-remark/package.json
@@ -23,7 +23,7 @@
     "remark-retext": "^4.0.0",
     "remark-stringify": "^9.0.1",
     "retext-english": "^3.0.4",
-    "sanitize-html": "^1.27.5",
+    "sanitize-html": "^2.3.0",
     "underscore.string": "^3.3.5",
     "unified": "^9.2.1",
     "unist-util-remove-position": "^3.0.0",


### PR DESCRIPTION
see here why unable to use gatsby-transform-remark without this fix : https://snyk.io/vuln/SNYK-JS-SANITIZEHTML-585892

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
